### PR TITLE
Increase tracking rate

### DIFF
--- a/alvr/client/src/connection.rs
+++ b/alvr/client/src/connection.rs
@@ -413,7 +413,7 @@ async fn connection_pipeline(
         }
     });
 
-    let tracking_interval = Duration::from_secs_f32(1_f32 / (config_packet.fps * 3_f32));
+    let tracking_interval = Duration::from_secs_f32(1_f32 / 360_f32);
     let tracking_loop = async move {
         let mut deadline = Instant::now();
         loop {

--- a/alvr/server/cpp/alvr_server/PoseHistory.cpp
+++ b/alvr/server/cpp/alvr_server/PoseHistory.cpp
@@ -31,7 +31,7 @@ void PoseHistory::OnPoseUpdated(const TrackingInfo &info) {
 			m_poseBuffer.push_back(history);
 		}
 	}
-	if (m_poseBuffer.size() > 10) {
+	if (m_poseBuffer.size() > 36) {
 		m_poseBuffer.pop_front();
 	}
 }


### PR DESCRIPTION
Send tracking at 360hz (lowest common multiple)
Pose buffer max size is higher to mitigate stutter